### PR TITLE
Use server.stop() method directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ exports.register = function(server, options, done) {
   process.on('message', function(msg) {
     if (msg === 'shutdown') {
       server.log(['info', 'pm2', 'shutdown'], 'stopping hapi...');
-      server.root.stop(options, function() {
+      server.stop(options, function() {
         server.log(['info', 'pm2', 'shutdown'], 'hapi stopped');
         return process.exit(0);
       });

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "test": "lab -c -t 100",
     "coveralls": "lab -t 100 -r lcov | coveralls"
   },
-  "git-pre-hooks": {
-    "pre-push": "npm test"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/roylines/hapi-graceful-pm2.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-graceful-pm2",
-  "version": "1.0.0",
+  "version": "1.0.13",
   "description": "hapi plugin to handle graceful pm2 reloads",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "test": "lab -c -t 100",
     "coveralls": "lab -t 100 -r lcov | coveralls"
   },
+  "git-pre-hooks": {
+    "pre-push": "npm test"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/roylines/hapi-graceful-pm2.git"

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,7 @@ lab.experiment("hapi-graceful-pm2", () => {
   lab.beforeEach((done) => {
     sinon.stub(process, 'on').returns();
     sinon.stub(process, 'exit');
-    server.root = {};
-    server.root.stop = sinon.stub();
+    server.stop = sinon.stub();
     server.log = sinon.stub();
 
     return plugin.register(server, options, done);
@@ -41,11 +40,11 @@ lab.experiment("hapi-graceful-pm2", () => {
 
   lab.test("should stop server if shutdown", (done) => {
     server.log.returns();
-    server.root.stop.yields();
+    server.stop.yields();
     process.exit.restore();
     sinon.stub(process, 'exit', function(code) {
       code.should.equal(0);
-      server.root.stop.calledOnce.should.be.true;
+      server.stop.calledOnce.should.be.true;
       return done();
     });
     


### PR DESCRIPTION
Just a minor update to use the `server.stop()` method of hapi server directly instead of using `server.root.stop()`.
